### PR TITLE
fix ruleset deserializer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use rocket::config::{Config, Environment};
 use rocket::http::Status;
 use rocket_contrib::json::{Json, JsonValue};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
 
@@ -21,7 +22,7 @@ mod logic;
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Game {
     id: String,
-    ruleset: HashMap<String, String>,
+    ruleset: HashMap<String, Value>,
     timeout: u32,
 }
 


### PR DESCRIPTION
the ruleset has changed. Now it has property that aren't strings

```
{
    "name":"standard",
    "version":"v1.0.20",
    "settings":{
        "foodspawnchance":15,
        "minimumfood":1,
        "hazarddamageperturn":0,
        "royale":{
            "shrinkeverynturns":0
        },
        "squad":{
            "allowbodycollisions":false,
            "sharedelimination":false,
            "sharedhealth":false,
            "sharedlength":false
        }
    }
}
```