### PR TITLE
change u32 to i32 since negative values are used

### DIFF
--- a/src/logic.rs
+++ b/src/logic.rs
@@ -33,19 +33,19 @@ pub fn info() -> Value {
 }
 
 // start is called when your Battlesnake begins a game
-pub fn start(_game: &Game, _turn: &u32, _board: &Board, _you: &Battlesnake) {
+pub fn start(_game: &Game, _turn: &i32, _board: &Board, _you: &Battlesnake) {
     info!("GAME START");
 }
 
 // end is called when your Battlesnake finishes a game
-pub fn end(_game: &Game, _turn: &u32, _board: &Board, _you: &Battlesnake) {
+pub fn end(_game: &Game, _turn: &i32, _board: &Board, _you: &Battlesnake) {
     info!("GAME OVER");
 }
 
 // move is called on every turn and returns your next move
 // Valid moves are "up", "down", "left", or "right"
 // See https://docs.battlesnake.com/api/example-move for available data
-pub fn get_move(_game: &Game, turn: &u32, _board: &Board, you: &Battlesnake) -> Value {
+pub fn get_move(_game: &Game, turn: &i32, _board: &Board, you: &Battlesnake) -> Value {
     
     let mut is_move_safe: HashMap<_, _> = vec![
         ("up", true),

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ pub struct Game {
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Board {
     height: u32,
-    width: u32,
+    width: i32,
     food: Vec<Coord>,
     snakes: Vec<Battlesnake>,
     hazards: Vec<Coord>,
@@ -35,24 +35,24 @@ pub struct Board {
 pub struct Battlesnake {
     id: String,
     name: String,
-    health: u32,
+    health: i32,
     body: Vec<Coord>,
     head: Coord,
-    length: u32,
+    length: i32,
     latency: String,
     shout: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Coord {
-    x: u32,
-    y: u32,
+    x: i32,
+    y: i32,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct GameState {
     game: Game,
-    turn: u32,
+    turn: i32,
     board: Board,
     you: Battlesnake,
 }


### PR DESCRIPTION
_Changed all u32 to i32 since negative values are used._
De-serialization errors were experienced when running vanilla starter-snake-rust (no logic added) within Battlesnake battles since the game servers seem to sometimes send negative values.

In Rust, unsigned integers are unable to hold negative values, resulting in the deserialization error.

Since this is a runtime error the only way to test was to run ~15+ test battles, with no errors displayed, to verify the changes had the desired result.

```"invalid value: integer `-1`, expected u32"```

Example error
```Dec 05 23:52:18 spinach run.sh[212283]: [2023-12-06T04:52:18Z WARN  _] `Json < GameState >` data guard failed: Parse("{\"game\":{\"id\":\"3f77dbb1-e39c-4b96-8dbf-e9be7b26e8de\",\"ruleset\":{\"name\":\"standard\",\"version\":\"v1.2.3\",\"settings\":{\"foodSpawnChance\":15,\"minimumFood\":1,\"hazardDamagePerTurn\":0,\"hazardMap\":\"\",\"hazardMapAuthor\":\"\",\"royale\":{\"shrinkEveryNTurns\":0},\"squad\":{\"allowBodyCollisions\":false,\"sharedElimination\":false,\"sharedHealth\":false,\"sharedLength\":false}}},\"map\":\"standard\",\"timeout\":500,\"source\":\"custom\"},\"turn\":3,\"board\":{\"height\":11,\"width\":11,\"snakes\":[{\"id\":\"gs_X9SyBtrMbSxrBHFPQX8pBpcF\",\"name\":\"Hungry Bot\",\"latency\":\"1\",\"health\":99,\"body\":[{\"x\":7,\"y\":0},{\"x\":8,\"y\":0},{\"x\":8,\"y\":1},{\"x\":9,\"y\":1}],\"head\":{\"x\":7,\"y\":0},\"length\":4,\"shout\":\"\",\"squad\":\"\",\"customizations\":{\"color\":\"#00cc00\",\"head\":\"alligator\",\"tail\":\"alligator\"}}],\"food\":[{\"x\":0,\"y\":2},{\"x\":5,\"y\":5}],\"hazards\":[]},\"you\":{\"id\":\"gs_qvG7jgBDJfBqjwwjr9phKV8R\",\"name\":\"firstsnake\",\"latency\":\"28\",\"health\":97,\"body\":[{\"x\":2,\"y\":-1},{\"x\":2,\"y\":0},{\"x\":2,\"y\":1}],\"head\":{\"x\":2,\"y\":-1},\"length\":3,\"shout\":\"\",\"squad\":\"\",\"customizations\":{\"color\":\"#62a832\",\"head\":\"default\",\"tail\":\"default\"}}}", Error("invalid value: integer `-1`, expected u32", line: 1, column: 891)).```